### PR TITLE
Use GitHub Action Workflows from `cloudposse/.github` Repo

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -4,19 +4,16 @@ on:
   push:
     branches:
       - main
-      - release/**
+      - release/v*
     paths-ignore:
       - '.github/**'
       - 'docs/**'
       - 'examples/**'
       - 'test/**'
 
-permissions:
-  contents: write
-  id-token: write
+permissions: {}
 
 jobs:
   terraform-module:
-    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/release-branch.yml@max-lobur-patch-1
-    secrets:
-      github_access_token: ${{ secrets.REPO_ACCESS_TOKEN }}
+    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/release-branch.yml@main
+    secrets: inherit

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -5,10 +5,9 @@ on:
     types:
       - published
 
-permissions:
-  contents: write
-  id-token: write
+permissions: {}
 
 jobs:
   terraform-module:
-    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/release.yml@main
+    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/release-published.yml@main
+    secrets: inherit


### PR DESCRIPTION
## what

- Install latest GitHub Action Workflows

## why

- Use shared workflows from `cldouposse/.github` repository
- Simplify management of workflows from centralized hub of configuration
