### PR TITLE
Update GitHub Workflows to use shared workflows from '.github' repo

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -1,5 +1,5 @@
 ---
-name: release-branch
+name: Branch
 on:
   pull_request:
     branches:
@@ -21,5 +21,5 @@ permissions: {}
 
 jobs:
   terraform-module:
-    uses: cloudposse/.github/.github/workflows/shared-terraform-module.yml@shared-workflows
+    uses: cloudposse/.github/.github/workflows/shared-terraform-module.yml@main
     secrets: inherit

--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -11,6 +11,6 @@ permissions:
 
 jobs:
   terraform-module:
-    uses: cloudposse/.github/.github/workflows/shared-terraform-chatops.yml@shared-workflows
+    uses: cloudposse/.github/.github/workflows/shared-terraform-chatops.yml@main
     secrets:
       github_access_token: ${{ secrets.REPO_ACCESS_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 ---
-name: release-published
+name: release
 on:
   release:
     types:
@@ -9,5 +9,5 @@ permissions: {}
 
 jobs:
   terraform-module:
-    uses: cloudposse/.github/.github/workflows/shared-release-branches.yml@shared-workflows
+    uses: cloudposse/.github/.github/workflows/shared-release-branches.yml@main
     secrets: inherit

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -12,5 +12,5 @@ permissions:
 
 jobs:
   scheduled:
-    uses: cloudposse/.github/.github/workflows/shared-terraform-scheduled.yml@shared-workflows
+    uses: cloudposse/.github/.github/workflows/shared-terraform-scheduled.yml@main
     secrets: inherit


### PR DESCRIPTION
## what
- Update workflows (`.github/workflows`) to use shared workflows from `.github` repo

## why
- Reduce nested levels of reusable workflows
